### PR TITLE
Differentiate non-specific digest and "no cleavage" in Enzyme constructor

### DIFF
--- a/src/main/java/edu/ucsd/msjava/msutil/Enzyme.java
+++ b/src/main/java/edu/ucsd/msjava/msutil/Enzyme.java
@@ -65,33 +65,15 @@ public class Enzyme implements ParamObject {
     private Enzyme(String name, String residues, boolean isNTerm, String description, String psiCvAccession) {
         this.name = name;
         this.description = description;
-        /* +++Start CWRU-CPB
-         *
-         * null is passed as the residue string for both non-specific and
+        /* null is passed as the residue string for both non-specific and
          * "no cleavage", so in order to distiguish the desired behavior we
          * inspect the controlled vocabulary name of the enzyme to determine if
          * if it is "no cleavage"
-         *
          */
         if (psiCvAccession != null && psiCvAccession.equals("MS:1001955")) {
-            AminoAcidSet aminoAcids = AminoAcidSet.getStandardAminoAcidSet();
-            this.residues = new char[aminoAcids.size()];
+            this.residues = new char[0];
             this.isResidueCleavable = new boolean[128];
-            int i = 0;
-            for(AminoAcid aminoAcid : aminoAcids) {
-                char residue = aminoAcid.getResidue();
-                if (!Character.isUpperCase(residue)) {
-                    System.err.println("Enzyme residues must be upper cases: " + residue);
-                    System.exit(-1);
-                }
-                this.residues[i] = residue;
-                isResidueCleavable[residue] = false;
-                i++;
-            }
         }   
-        /*
-         * +++End CWRU-CPB
-         */
         
         else if (residues != null) {
             this.residues = new char[residues.length()];

--- a/src/main/java/edu/ucsd/msjava/msutil/Enzyme.java
+++ b/src/main/java/edu/ucsd/msjava/msutil/Enzyme.java
@@ -65,7 +65,35 @@ public class Enzyme implements ParamObject {
     private Enzyme(String name, String residues, boolean isNTerm, String description, String psiCvAccession) {
         this.name = name;
         this.description = description;
-        if (residues != null) {
+        /* +++Start CWRU-CPB
+         *
+         * null is passed as the residue string for both non-specific and
+         * "no cleavage", so in order to distiguish the desired behavior we
+         * inspect the controlled vocabulary name of the enzyme to determine if
+         * if it is "no cleavage"
+         *
+         */
+        if (psiCvAccession != null && psiCvAccession.equals("MS:1001955")) {
+            AminoAcidSet aminoAcids = AminoAcidSet.getStandardAminoAcidSet();
+            this.residues = new char[aminoAcids.size()];
+            this.isResidueCleavable = new boolean[128];
+            int i = 0;
+            for(AminoAcid aminoAcid : aminoAcids) {
+                char residue = aminoAcid.getResidue();
+                if (!Character.isUpperCase(residue)) {
+                    System.err.println("Enzyme residues must be upper cases: " + residue);
+                    System.exit(-1);
+                }
+                this.residues[i] = residue;
+                isResidueCleavable[residue] = false;
+                i++;
+            }
+        }   
+        /*
+         * +++End CWRU-CPB
+         */
+        
+        else if (residues != null) {
             this.residues = new char[residues.length()];
             this.isResidueCleavable = new boolean[128];
             for (int i = 0; i < residues.length(); i++) {


### PR DESCRIPTION
Observed behavior: Requesting "no cleavage" enzyme was resulting in non-specific digest

Proposed modification: null is passed as the residue string for both non-specific and "no cleavage" to the Enzyme constructor. We added logic to inspect the controlled vocabulary term passed to differentiate requests for "no cleavage" and for such requests we set isResidueCleavable[amino acid]=false for all amino acids defined in the standard set.