### PR TITLE
Add maximum missed cleavage parameter

### DIFF
--- a/src/main/java/edu/ucsd/msjava/msdbsearch/CandidatePeptideGrid.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/CandidatePeptideGrid.java
@@ -2,15 +2,21 @@ package edu.ucsd.msjava.msdbsearch;
 
 import edu.ucsd.msjava.msutil.AminoAcid;
 import edu.ucsd.msjava.msutil.AminoAcidSet;
+import edu.ucsd.msjava.msutil.Enzyme;
 import edu.ucsd.msjava.msutil.Modification.Location;
 
 public class CandidatePeptideGrid {
     private static final int STANDARD_RESIDUE_MAX_RESIDUE = 128;
 
     private final AminoAcidSet aaSet;
+    private final Enzyme enzyme;
     private final int maxPeptideLength;
     private final int numMaxMods;
     private final int maxNumVariantsPerPeptide;
+    private final int maxNumMissedCleavages;
+    private final int[] nMissedCleavages;
+    private final char[] residues;
+    private final boolean enzymeIsNonSpecific;
 
     private int[][] nominalPRM;
     private double[][] prm;
@@ -53,11 +59,14 @@ public class CandidatePeptideGrid {
 //		this(aaSet, maxPeptideLength, Constants.NUM_VARIANTS_PER_PEPTIDE);
 //	}
 
-    public CandidatePeptideGrid(AminoAcidSet aaSet, int maxPeptideLength, int maxNumVariantsPerPeptide) {
+    public CandidatePeptideGrid(AminoAcidSet aaSet, Enzyme enzyme, int maxPeptideLength, int maxNumVariantsPerPeptide, int maxMissedCleavages) {
         this.numMaxMods = aaSet.getMaxNumberOfVariableModificationsPerPeptide();
         this.maxPeptideLength = maxPeptideLength;
         this.maxNumVariantsPerPeptide = maxNumVariantsPerPeptide;
+        this.maxNumMissedCleavages=maxMissedCleavages;
         this.aaSet = aaSet;
+        this.enzyme = enzyme;
+        this.enzymeIsNonSpecific = enzyme.getName().equals("UnspecificCleavage");
 
         cacheAASet();
 
@@ -66,6 +75,8 @@ public class CandidatePeptideGrid {
         numMods = new int[maxNumVariantsPerPeptide][maxPeptideLength + 1];
         peptide = new StringBuffer[maxNumVariantsPerPeptide];
         size = new int[maxPeptideLength + 1];
+        nMissedCleavages = new int[maxPeptideLength + 1];
+        residues = new char[maxPeptideLength + 1];
 
         initializeNTerm();
     }
@@ -78,6 +89,8 @@ public class CandidatePeptideGrid {
             peptide[i] = new StringBuffer();
         }
         size[0] = 1;
+        nMissedCleavages[0]=0;
+        residues[0] = '_';
         length = 0;
     }
 
@@ -103,6 +116,40 @@ public class CandidatePeptideGrid {
 
     public String getPeptideSeq(int index) {
         return peptide[index].toString();
+    }
+
+    /**
+     * Test whether the peptide currently represented by the grid contains more
+     * than the maximum number of allowed missed cleavages.
+     *
+     * @param index This parameter is unused, but is necessary because of how
+     * this class is extended by CandidatePeptideGridConsideringMetCleavage,
+     * which uses the index to route the call to one of two different grids.
+     *
+     * @return true for over the maximum number of allowed missed cleavages,
+     * false otherwise.
+     *
+     * @see CandidatePeptideGridConsideringMetCleavage
+     */
+    public boolean gridIsOverMaxMissedCleavages(int index) {
+        return maxNumMissedCleavages != -1 && nMissedCleavages[length] > maxNumMissedCleavages;
+    }
+
+    /**
+     * Return the number of missed cleavages in the peptides the grid is
+     * representing.
+     *
+     * @param index This parameter is unused, but is necessary because of how
+     * this class is extended by CandidatePeptideGridConsideringMetCleavage,
+     * which uses the index to route the call to one of two different grids.
+     *
+     * @return The number of missed cleavages in the current grid peptide
+     * sequence.
+     *
+     * @see CandidatePeptideGridConsideringMetCleavage
+     */
+    public int getPeptideNumMissedCleavages(int index) {
+        return nMissedCleavages[length];
     }
 
     public int getNumMods(int index) {
@@ -213,6 +260,48 @@ public class CandidatePeptideGrid {
         }
 
         this.length = length;
+
+        /* If we are imposing a limit on the maximum number of missed cleavages
+         * allowed on candidate peptides.
+         */
+        if(maxNumMissedCleavages != -1 && !enzymeIsNonSpecific) {
+            /* If enzyme cleaves before the amino acid (N-term enzyme), and this
+             * is not the first amino acid of the peptide, then it is a missed
+             * cleavage.
+             *
+             * E.g., AspN cleaves before D, so peptide YYD has a missed cleavage
+             * at position 3, but peptide DYY has no missed cleavages.
+             */
+            if(enzyme.isCleavable(aaResidueArr[0]) && enzyme.isNTerm() && length > 1) {
+                nMissedCleavages[length] = nMissedCleavages[length-1] + 1;
+            }
+
+            /* For C-term enzymes, we need to look backward one residue to
+             * determine if adding this residue creates a missed cleavage.
+             *
+             * E.g., for Trpysin, if the previous residue is K but we are
+             * extending the peptide with another amino acid, the new peptide
+             * has 1 missed cleavage at position length-1 because the K did not
+             * cleave.
+             */
+            else if(enzyme.isCTerm() && enzyme.isCleavable(residues[length-1])) {
+                nMissedCleavages[length] = nMissedCleavages[length-1] + 1;
+            }
+
+            /* Otherwise, the number of missed cleavages stays the same as the
+             * previous peptide. */
+            else {
+                nMissedCleavages[length] = nMissedCleavages[length-1];
+            }
+
+            /* Store the look back residue to avoid repeated String parsing */
+            residues[length]=aaResidueArr[0];
+
+            /* Return false if the new peptide is over the maximum numer of
+             * missed cleavages */
+            if(nMissedCleavages[length] > maxNumMissedCleavages) return false;
+        }
+
         return true;
     }
 

--- a/src/main/java/edu/ucsd/msjava/msdbsearch/ConcurrentMSGFDB.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/ConcurrentMSGFDB.java
@@ -94,7 +94,7 @@ public class ConcurrentMSGFDB {
                 boolean replicateMergedResults
         ) {
             this.specScanner = specScanner;
-            this.scanner = new DBScanner(specScanner, sa, enzyme, aaSet, numPeptidesPerSpec, minPeptideLength, maxPeptideLength, Constants.NUM_VARIANTS_PER_PEPTIDE, 0, false);
+            this.scanner = new DBScanner(specScanner, sa, enzyme, aaSet, numPeptidesPerSpec, minPeptideLength, maxPeptideLength, Constants.NUM_VARIANTS_PER_PEPTIDE, 0, false, -1);
             this.numberOfAllowableNonEnzymaticTermini = numberOfAllowableNonEnzymaticTermini;
             this.storeScoreDist = storeScoreDist;
             this.specFileName = specFileName;

--- a/src/main/java/edu/ucsd/msjava/msdbsearch/ConcurrentMSGFPlus.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/ConcurrentMSGFPlus.java
@@ -45,7 +45,8 @@ public class ConcurrentMSGFPlus {
                     params.getMaxPeptideLength(),
                     params.getMaxNumVariatsPerPeptide(),
                     params.getMinDeNovoScore(),
-                    params.ignoreMetCleavage()
+                    params.ignoreMetCleavage(),
+                    params.getMaxMissedCleavages()
             );
             this.resultList = resultList;
             this.taskNum = taskNum;

--- a/src/main/java/edu/ucsd/msjava/msdbsearch/DBScanner.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/DBScanner.java
@@ -17,7 +17,7 @@ public class DBScanner {
 
     private int minPeptideLength;
     private int maxPeptideLength;
-
+    private int maxMissedCleavages;
     private int maxNumVariantsPerPeptide;
 
     private AminoAcidSet aaSet;
@@ -56,7 +56,8 @@ public class DBScanner {
             int maxPeptideLength,
             int maxNumVariantsPerPeptide,
             int minDeNovoScore,
-            boolean ignoreNTermMetCleavage
+            boolean ignoreNTermMetCleavage,
+            int maxMissedCleavages
     ) {
         this.specScanner = specScanner;
         this.sa = sa;
@@ -66,6 +67,7 @@ public class DBScanner {
         this.numPeptidesPerSpec = numPeptidesPerSpec;
         this.minPeptideLength = minPeptideLength;
         this.maxPeptideLength = maxPeptideLength;
+        this.maxMissedCleavages = maxMissedCleavages;
         this.maxNumVariantsPerPeptide = maxNumVariantsPerPeptide;
         this.minDeNovoScore = minDeNovoScore;
         this.ignoreNTermMetCleavage = ignoreNTermMetCleavage;
@@ -184,9 +186,9 @@ public class DBScanner {
 
         CandidatePeptideGrid candidatePepGrid;
         if (enzyme != null && !ignoreNTermMetCleavage)
-            candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aaSet, maxPeptideLength, maxNumVariantsPerPeptide);
+            candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aaSet, enzyme, maxPeptideLength, maxNumVariantsPerPeptide, maxMissedCleavages);
         else
-            candidatePepGrid = new CandidatePeptideGrid(aaSet, maxPeptideLength, maxNumVariantsPerPeptide);
+            candidatePepGrid = new CandidatePeptideGrid(aaSet, enzyme, maxPeptideLength, maxNumVariantsPerPeptide, maxMissedCleavages);
 
         int peptideLengthIndex = Integer.MAX_VALUE - 1000;
 
@@ -432,6 +434,23 @@ public class DBScanner {
                         if (Thread.currentThread().isInterrupted()) {
                             return;
                         }
+
+                        /* 
+                         * Check for edge case where peptides derived from the
+                         * start of a protien sequence containing an N-terminus
+                         * methionine may have more missed cleavages than the
+                         * peptides derived from removing the methionine when
+                         * digesting with N-term enzymes.
+                         *
+                         * E.g., a grid that considers methionine cleavage on
+                         * protein sequence 'MDT' will return peptides
+                         * ['MDT','DT']. If we are using AspN as the enzyme
+                         * the MDT peptide has one missed cleavage and the DT
+                         * peptide has zero. We want to skip the peptides that
+                         * are over the maximum number of missed cleavages.
+                         *
+                         */
+                        if(candidatePepGrid.gridIsOverMaxMissedCleavages(j)) continue;
 
                         float theoPeptideMass = candidatePepGrid.getPeptideMass(j);
 //						/// Debug

--- a/src/main/java/edu/ucsd/msjava/msdbsearch/PeptideEnumerator.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/PeptideEnumerator.java
@@ -64,7 +64,8 @@ public class PeptideEnumerator {
 
         Enzyme enzyme = Enzyme.TRYPSIN;
 
-        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aaSet, MAX_PEPTIDE_LENGTH, Constants.NUM_VARIANTS_PER_PEPTIDE);
+        /* No limit on maximum number of missed cleavages */
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aaSet, enzyme, MAX_PEPTIDE_LENGTH, Constants.NUM_VARIANTS_PER_PEPTIDE, -1);
         int[] numMissedCleavages = new int[MAX_PEPTIDE_LENGTH + 1];
         int nnet = 0;
         for (int bufferIndex = 0; bufferIndex < size; bufferIndex++) {

--- a/src/main/java/edu/ucsd/msjava/msdbsearch/SearchParams.java
+++ b/src/main/java/edu/ucsd/msjava/msdbsearch/SearchParams.java
@@ -50,6 +50,7 @@ public class SearchParams {
     private int minNumPeaksPerSpectrum;
     private int minDeNovoScore;
     private double chargeCarrierMass;
+    private int maxMissedCleavages;
 
     public SearchParams() {
     }
@@ -182,11 +183,15 @@ public class SearchParams {
         return chargeCarrierMass;
     }
 
+    public int getMaxMissedCleavages() {
+        return maxMissedCleavages;
+    }
+
     public String parse(ParamManager paramManager) {
         // Charge carrier mass
         chargeCarrierMass = paramManager.getDoubleValue("ccm");
         Composition.setChargeCarrierMass(chargeCarrierMass);
-        
+
         // Spectrum file
         FileParameter specParam = paramManager.getSpecFileParam();
         File specPath = specParam.getFile();
@@ -317,6 +322,20 @@ public class SearchParams {
 
         minDeNovoScore = paramManager.getIntValue("minDeNovoScore");
 
+        /* Make sure max missed cleavages is valid value and that it is not
+         * being mixed with an unspecific or no-cleave enzyme
+         *
+         * String comparison to name is fragile here. It would be better if
+         * there was a stable identifier to use for the comparision.
+         */
+        maxMissedCleavages = paramManager.getIntValue("maxMissedCleavages");
+        if(maxMissedCleavages > -1 && enzyme.getName().equals("UnspecificCleavage")) {
+            return "Cannot specify a MaxMissedCleavages when using unspecific cleavage enzyme";
+        }
+        else if(maxMissedCleavages > -1 && enzyme.getName().equals("NoCleavage")) {
+            return "Cannot specify a MaxMissedCleavages when using no cleavage enzyme";
+        }
+
         return null;
     }
 
@@ -348,7 +367,7 @@ public class SearchParams {
         buf.append("\tMinPeptideLength: " + this.minPeptideLength + "\n");
         buf.append("\tMaxPeptideLength: " + this.maxPeptideLength + "\n");
         buf.append("\tNumMatchesPerSpec: " + this.numMatchesPerSpec + "\n");
-
+        buf.append("\tMaxMissedCleavages: "+this.maxMissedCleavages + "\n");
         buf.append("\tChargeCarrierMass: " + this.chargeCarrierMass);
 
         if (Math.abs(this.chargeCarrierMass - PROTON) < 0.005) {

--- a/src/main/java/edu/ucsd/msjava/params/ParamManager.java
+++ b/src/main/java/edu/ucsd/msjava/params/ParamManager.java
@@ -348,12 +348,18 @@ public class ParamManager {
         addFeatureParam.registerEntry("output basic scores only").setDefault();
         addFeatureParam.registerEntry("output additional features");
         addParameter(addFeatureParam);
-        
+
         DoubleParameter chargeCarrierMassParam = new DoubleParameter("ccm", "ChargeCarrierMass", "Mass of charge carrier, Default: mass of proton (1.00727649)");
         chargeCarrierMassParam.minValue(0.1);
         chargeCarrierMassParam.setMaxInclusive();
         chargeCarrierMassParam.defaultValue(Composition.PROTON);
         addParameter(chargeCarrierMassParam);
+
+        /* Maximum number of missed cleavages to allow on searched pepetides */
+        IntParameter maxMissedCleavages = new IntParameter("maxMissedCleavages", "MaxMissedCleavages", "Exclude peptides with more than this number of missed cleavages from the search, Default: -1 (no limit)");
+        maxMissedCleavages.minValue(-1);
+        maxMissedCleavages.defaultValue(-1);
+        addParameter(maxMissedCleavages);
 
         addExample("Example (high-precision): java -Xmx3500M -jar MSGFPlus.jar -s test.mzXML -d IPI_human_3.79.fasta -t 20ppm -ti -1,2 -ntt 2 -tda 1 -o testMSGFPlus.mzid");
         addExample("Example (low-precision): java -Xmx3500M -jar MSGFPlus.jar -s test.mzXML -d IPI_human_3.79.fasta -t 0.5Da,2.5Da -ntt 2 -tda 1 -o testMSGFPlus.mzid");

--- a/src/test/java/msgfplus/TestCandidatePeptideGrid.java
+++ b/src/test/java/msgfplus/TestCandidatePeptideGrid.java
@@ -1,0 +1,234 @@
+package msgfplus;
+
+import edu.ucsd.msjava.msdbsearch.CandidatePeptideGrid;
+import edu.ucsd.msjava.msutil.AminoAcidSet;
+import edu.ucsd.msjava.msutil.Enzyme;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+
+public class TestCandidatePeptideGrid {
+
+    private void printCandidatePeptideGrid(CandidatePeptideGrid candidatePepGrid) {
+        System.out.printf("-------GRID--------\n");
+        for(int j=0;j<candidatePepGrid.size();j++) {
+            System.out.printf("%d : %s\n",j,candidatePepGrid.getPeptideSeq(j));
+        }
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_No_Modified_Residues()
+    {
+        System.out.println("Test Unmodified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("No modifications, so size should stay 1",1,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("No modifications, so size should stay 1",1,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("No modifications, so size should stay 1",1,candidatePepGrid.size());
+
+        assertEquals("Should contain only the peptide AAA","AAA",candidatePepGrid.getPeptideSeq(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Modified_Residues()
+    {
+        System.out.println("Test Modified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('S');
+        assertEquals("1 variably modified residue, grid size should be 2",2,candidatePepGrid.size());
+
+
+        candidatePepGrid.addResidue(2,'T');
+        assertEquals("2 variably modified residues, grid size should be 4",4,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'Y');
+        assertEquals("3 variably modified residues, grid size should be 8",8,candidatePepGrid.size());
+
+        assertEquals("The peptide in position 0 should be the unmodified sequence","STY",candidatePepGrid.getPeptideSeq(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Modified_and_Unmodified_Residues()
+    {
+        System.out.println("Test Mixture of Modified and Unmodified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('S');
+        assertEquals("1 variably modified residue, grid size should be 2",2,candidatePepGrid.size());
+
+
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("1 variably modified residue, and one unmodified residue, grid size should be 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'Y');
+        assertEquals("2 variably modified residues, and one unmodified residue, grid size should be 4",4,candidatePepGrid.size());
+
+        assertEquals("The peptide in position 0 should be the unmodified sequence","SAY",candidatePepGrid.getPeptideSeq(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Size_Reset()
+    {
+        System.out.println("Test Reusing the Grid for a New Peptide");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('S');
+        candidatePepGrid.addResidue(2,'A');
+        candidatePepGrid.addResidue(3,'Y');
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("Reusing grid, size should be 1",1,candidatePepGrid.size());
+        assertEquals("Reusing grid, peptide should be 'A'","A",candidatePepGrid.getPeptideSeq(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_CTerm_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - C-term Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("First amino acid A when cleaving with Trypsin should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('K');
+        assertEquals("First amino acid K when cleaving with Trypsin should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        candidatePepGrid.addResidue(2,'R');
+        assertEquals("Second amino acid R when cleaving with Trypsin should report 1 missed cleavage for peptide KR",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        boolean result = candidatePepGrid.addResidue(3,'A');
+        assertEquals("grid should return false trying to add 'A' to 'KR' because peptide KRA exceeds max 2 missed clavages",false,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("grid should return true that the peptide it represents exceeds max 2 missed clavages",true,result);
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_NTerm_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - N-term Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.AspN, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('D');
+        assertEquals("First amino acid D when cleaving with AspN should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("First amino acid A when cleaving with AspN should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addResidue(2,'D');
+        assertEquals("Second amino acid D when cleaving with AspN should report 1 missed cleavage for AD",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("Third amino acid A when cleaving with AspN should report 1 missed cleavage for ADA",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        boolean result = candidatePepGrid.addResidue(4,'D');
+        assertEquals("grid should return false trying to add 'D' to 'ADA' because it exceeds max 2 missed clavages",false,result);
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_NoCleavage_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - NoCleavage");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.NoCleavage, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("First amino acid A with no-cleave enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("Second amino acid A with no-cleave enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("Third amino acid A with no-cleave enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_Unspecific_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - Unspecific Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.UnspecificCleavage, 3, 8, 1);
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("First amino acid A with unspecific enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("Second amino acid A with unspecific enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("Third amino acid A with unspecific enzyme should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_Reuse()
+    {
+        System.out.println("Test Missed Cleavages When Reusing the Grid - Trypsin");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        /* Use till ti returns false */
+        candidatePepGrid.addNTermResidue('K');
+        candidatePepGrid.addResidue(2,'R');
+        candidatePepGrid.addResidue(3,'A');
+
+        /* Reuse, in the middle */
+        candidatePepGrid.addResidue(2,'R');
+        assertEquals("grid should return 1 missed cleavages on reuse",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        /* Reuse, in the middle */
+        candidatePepGrid.addResidue(2,'R');
+        assertEquals("grid should return 1 missed cleavages on reuse",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        /* Reuse */
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("grid should return 0 missed cleavages on reuse",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+    }
+
+    @Test
+    public void testCandidatePeptideGrid_Missed_Cleavages_No_Limit()
+    {
+        System.out.println("Test Missed Cleavages - No Limit on Maximum");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+
+        /* Passing -1 for max missed cleavages specifies 'unlimitted' */
+        CandidatePeptideGrid candidatePepGrid = new CandidatePeptideGrid(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, -1);
+
+        candidatePepGrid.addNTermResidue('A');
+        assertEquals("First amino acid A when cleaving with Trypsin should report 0 missed cleavages",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+
+        /* Generate two missed cleavages and test result is still true */
+        candidatePepGrid.addNTermResidue('K');
+        candidatePepGrid.addResidue(2,'R');
+        boolean result = candidatePepGrid.addResidue(3,'A');
+        assertEquals("grid should return true trying to add 'A' to 'KR' because no limit on number of missed cleavages",true,result);
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("grid should always return that it is under the max number of allowed missed cleavages",false,result);
+    }
+
+}

--- a/src/test/java/msgfplus/TestCandidatePeptideGridConsideringMetCleavage.java
+++ b/src/test/java/msgfplus/TestCandidatePeptideGridConsideringMetCleavage.java
@@ -1,0 +1,356 @@
+package msgfplus;
+
+import edu.ucsd.msjava.msdbsearch.CandidatePeptideGridConsideringMetCleavage;
+import edu.ucsd.msjava.msutil.AminoAcidSet;
+import edu.ucsd.msjava.msutil.Enzyme;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+
+public class TestCandidatePeptideGridConsideringMetCleavage {
+
+    private void printCandidatePeptideGridConsideringMetCleavage(CandidatePeptideGridConsideringMetCleavage candidatePepGrid) {
+        System.out.printf("-------GRID--------\n");
+        for(int j=0;j<candidatePepGrid.size();j++) {
+            System.out.printf("%d : %s\n",j,candidatePepGrid.getPeptideSeq(j));
+        }
+    }
+
+    /* Test the expected grid sizes when no modified residues are considered */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_No_Modified_Residues()
+    {
+        System.out.println("Test Unmodified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, 1);
+
+        /* Add a methionine, so the size should be 2 when the grid instantiates
+         * one grid for generating peptides with methionine and one for ones
+         * with methionine cleaved */
+        candidatePepGrid.addProtNTermResidue('M');
+        assertEquals("Methioinine should cause two grids to be instantiated with initial size 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("No modifications, so size should stay 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("No modifications, so size should stay 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(4,'A');
+        assertEquals("No modifications, so size should stay 2",2,candidatePepGrid.size());
+
+        assertEquals("Should contain only the peptide MAAA","MAAA",candidatePepGrid.getPeptideSeq(0));
+        assertEquals("Should contain only the peptide AAA","AAA",candidatePepGrid.getPeptideSeq(1));
+    }
+
+    /* Test the expected grid sizes when only modified residues are considered */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Modified_Residues()
+    {
+        System.out.println("Test Modified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, 1);
+
+        /* Add a methionine, so the size should be 2 when the grid instantiates
+         * one grid for generating peptides with methionine and one for ones
+         * with methionine cleaved */
+        candidatePepGrid.addProtNTermResidue('M');
+        assertEquals("Methioinine should cause two grids to be instantiated with initial size 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(2,'S');
+        assertEquals("1 variably modified residue, grid size should be 4",4,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'T');
+        assertEquals("2 variably modified residues, grid size should be 8",8,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(4,'Y');
+        assertEquals("3 variably modified residues, grid size should be 16",16,candidatePepGrid.size());
+
+        assertEquals("The peptide in position 0 should be the unmodified sequence","MSTY",candidatePepGrid.getPeptideSeq(0));
+        assertEquals("The peptide in position 8 should be the unmodified sequence","STY",candidatePepGrid.getPeptideSeq(8));
+    }
+
+    /* Test the expected grid sizes when both modified and unmodified residues
+     * are considered */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Modified_and_Unmodified_Residues()
+    {
+        System.out.println("Test Mixture of Modified and Unmodified Residues");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, 1);
+
+        /* Add a methionine, so the size should be 2 when the grid instantiates
+         * one grid for generating peptides with methionine and one for ones
+         * with methionine cleaved */
+        candidatePepGrid.addProtNTermResidue('M');
+        assertEquals("Methioinine should cause two grids to be instantiated with initial size 2",2,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(2,'S');
+        assertEquals("1 variably modified residue, grid size should be 4",4,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("1 variably modified residue, and one unmodified residue, grid size should be 4",4,candidatePepGrid.size());
+
+        candidatePepGrid.addResidue(4,'Y');
+        assertEquals("2 variably modified residues, and one unmodified residue, grid size should be 8",8,candidatePepGrid.size());
+
+        assertEquals("The peptide in position 0 should be the unmodified sequence","MSAY",candidatePepGrid.getPeptideSeq(0));
+        assertEquals("The peptide in position 5 should be the unmodified sequence","SAY",candidatePepGrid.getPeptideSeq(4));
+    }
+
+    /* Test that the grid size resets as expected when re-using the grid */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Size_Reset()
+    {
+        System.out.println("Test Reusing the Grid for a New Peptide");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+        candidatePepGrid.addNTermResidue('S');
+        candidatePepGrid.addResidue(2,'A');
+        candidatePepGrid.addResidue(3,'Y');
+
+        candidatePepGrid.addProtNTermResidue('M');
+        assertEquals("Reusing grid, size should be 2",2,candidatePepGrid.size());
+        assertEquals("Reusing grid, peptide at index 0 should be 'M'","M",candidatePepGrid.getPeptideSeq(0));
+        assertEquals("Reusing grid, peptide at index 1 should be ''","",candidatePepGrid.getPeptideSeq(1));
+    }
+
+    /* Test missed cleavage detection and reporting for the grids including and
+     * excluding methionine when using a C-term cleaving enzyme.
+     */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_CTerm_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - C-term Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+
+        /* Start out adding a non-cleaving amino acid to verify it returns 0
+         * missed cleavages */
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("Adding amino acid A to 'M' when cleaving with Trypsin should report 0 missed cleavages for [M]A",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to '' when cleaving with Trypsin should report 0 missed cleavages for A",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Start over adding a cleaving amino acid to verify it returns 0
+         * missed cleavages */
+        candidatePepGrid.addResidue(2,'K');
+        assertEquals("Adding amino acid K to 'M' when cleaving with Trypsin should report 0 missed cleavages for [M]K",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid K to '' when cleaving with Trypsin should report 0 missed cleavages for K",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Add another cleaving amino acid, which should turn the previous K
+         * into a missed cleavage */
+        candidatePepGrid.addResidue(3,'R');
+        assertEquals("Adding amino acid R to 'MK' when cleaving with Trypsin should report 1 missed cleavage for peptides MKR",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid R to K when cleaving with Trypsin should report 1 missed cleavage for peptides KR",1,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Test detection of over max rejecting addition and explict tests for
+         * over-max of the methionine and no-methionine grids */
+        boolean result = candidatePepGrid.addResidue(4,'A');
+        assertEquals("grid should return false trying to add 'A' to '[M]KR' because peptides [M]KRA exceed max 2 missed cleavages (both grids reject the addition)",false,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("grid including methionine should return true for overMax after adding 'A' to 'MKR' because peptide MKRA exceeds max 2 missed clavages",true,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(1);
+        assertEquals("grid excluding methionine should return true for overMax after adding 'A' to 'KR' because peptide KRA exceeds max 2 missed clavages",true,result);
+    }
+
+    /* Test missed cleavage detection and reporting for the grids including and
+     * excluding methionine when using an N-term cleaving enzyme.
+     */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_NTerm_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - N-term Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.AspN, 5, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+
+        /* Start out adding a non-cleaving amino acid to verify it returns 0
+         * missed cleavages */
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("Adding amino acid A to 'M' when cleaving with AspN should report 0 missed cleavages for MA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to '' when cleaving with AspN should report 0 missed cleavages for A",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Start over adding a cleaving amino acid to verify the grid that
+         * includes methionine reports 1 missed cleavage but the grid that
+         * excludes methionine reports 0 missed cleavages */
+        candidatePepGrid.addResidue(2,'D');
+        assertEquals("Adding amino acid D to 'M' when cleaving with AspN should report 1 missed cleavage for MD",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid D to '' when cleaving with AspN should report 0 missed cleavage for D",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Test the success of adding another 'D', and internal divergence of
+         * over-max for methionine and non-methionine grids */
+        boolean result = candidatePepGrid.addResidue(3,'D');
+        assertEquals("Adding D to should return true because it is under max missed clavages for 'DD' but not for 'MDD' (methionine grid rejected addition, the methionine cleaving grid accepted it)",true,result);
+        assertEquals("Adding amino acid D to 'MD' when cleaving with AspN should report 2 missed cleavages for MDD",2,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid D to 'D' when cleaving with AspN should report 1 missed cleavage for DD",1,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("grid including methionine should report that it is over the max number of missed cleavages",true,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(1);
+        assertEquals("grid excluding methionine should report that it is NOT over the max number of missed cleavages",false,result);
+
+        /* Test adding an additional missed cleavage triggers rejection by both
+         * grids */
+        result = candidatePepGrid.addResidue(4,'D');
+        assertEquals("grid should return false trying to add 'D' because both 'MDDD' and 'MDD' exceed max 2 missed cleavages",false,result);
+    }
+
+    /* Test missed cleavage detection and reporting for the grids including and
+     * excluding methionine when using an unspecific cleaving enzyme.
+     */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_Unspecific_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - Unspecific Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.UnspecificCleavage, 5, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+
+        /* First amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("Adding amino acid A to 'M' when cleaving with unspecific enzyme should report 0 missed cleavages for MA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to '' when cleaving with unspecific enzyme should report 0 missed cleavages for A",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Second amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("Adding amino acid A to 'MA' when cleaving with unspecific enzyme should report 0 missed cleavages for MAA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to 'A' when cleaving with unspecific enzyme should report 0 missed cleavages for AA",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Third amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("Adding amino acid A to 'MAA' when cleaving with unspecific enzyme should report 0 missed cleavages for MAAA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to 'AA' when cleaving with unspecific enzyme should report 0 missed cleavages for AAA",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+    }
+
+    /* Test missed cleavage detection and reporting for the grids including and
+     * excluding methionine when using an unspecific cleaving enzyme.
+     */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_NoCleavage_Enzyme()
+    {
+        System.out.println("Test Missed Cleavages - NoCleavage Enzyme");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.NoCleavage, 5, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+
+        /* First amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(2,'A');
+        assertEquals("Adding amino acid A to 'M' when cleaving with no-cleave enzyme should report 0 missed cleavages for MA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to '' when cleaving with no-cleave enzyme should report 0 missed cleavages for A",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Second amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("Adding amino acid A to 'MA' when cleaving with no-cleave enzyme should report 0 missed cleavages for MAA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to 'A' when cleaving with no-cleave enzyme should report 0 missed cleavages for AA",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Third amino acid should report 0 missed cleavages */
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("Adding amino acid A to 'MAA' when cleaving with no-cleave enzyme should report 0 missed cleavages for MAAA",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("Adding amino acid A to 'AA' when cleaving with no-cleave enzyme should report 0 missed cleavages for AAA",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+    }
+
+    /* The grids are instantiated once and reused many times. Test that
+     * shortening the peptide in the grid correctly rewinds the number of missed
+     * cleavages */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_Reuse()
+    {
+        System.out.println("Test Missed Cleavages When Reusing the Grid");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 3, 8, 1);
+
+        candidatePepGrid.addProtNTermResidue('M');
+
+        /* Use till it returns false */
+        candidatePepGrid.addResidue(2,'K');
+        candidatePepGrid.addResidue(3,'R');
+        candidatePepGrid.addResidue(4,'A');
+
+        /* Reuse, at begining to give 0 missed cleavages */
+        candidatePepGrid.addResidue(2,'R');
+        assertEquals("methionine grid should return 0 missed cleavages on reuse",0,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("grid should return 0 missed cleavages on reuse",0,candidatePepGrid.getPeptideNumMissedCleavages(1));
+
+        /* Add residue after R to trigger missed cleavage */
+        candidatePepGrid.addResidue(3,'A');
+        assertEquals("methionine grid should return 1 missed cleavages on reuse",1,candidatePepGrid.getPeptideNumMissedCleavages(0));
+        assertEquals("grid should return 1 missed cleavages on reuse",1,candidatePepGrid.getPeptideNumMissedCleavages(1));
+    }
+
+    /* Specifying -1 for max missed clavages specifies 'unlimited' which can
+     * be used as default behavior for backward compatibility */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_Missed_Cleavages_No_Limit()
+    {
+        System.out.println("Test Missed Cleavages - No Limit on Maximum");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+
+        /* Passing -1 for max missed cleavages specified 'unlimited' */
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, -1);
+
+        /* Generate two missed cleavages and test result is still true */
+        candidatePepGrid.addProtNTermResidue('M');
+        candidatePepGrid.addResidue(2,'K');
+        candidatePepGrid.addResidue(3,'R');
+        boolean result = candidatePepGrid.addResidue(4,'A');
+        assertEquals("grid should return true trying to add 'A' to 'KR' because no limit on number of missed cleavages",true,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("methionine grid should always return that it is under the max number of allowed missed cleavages",false,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(1);
+        assertEquals("grid should always return that it is under the max number of allowed missed cleavages",false,result);
+    }
+
+    /* Specifying -1 for max missed clavages specifies 'unlimited' which can
+     * be used as default behavior for backward compatibility */
+    @Test
+    public void testCandidatePeptideGridConsideringMetCleavage_No_Missed_Cleavages_Allowed()
+    {
+        System.out.println("Test Missed Cleavages - No Limit on Maximum");
+        File dir = new File("src/test/resources");
+        AminoAcidSet aminoAcidSet = AminoAcidSet.getAminoAcidSetFromModFile(dir.getPath()+File.separator+"mods/TestCandidatePeptideGrid.txt");
+
+        /* Passing -1 for max missed cleavages specified 'unlimited' */
+        CandidatePeptideGridConsideringMetCleavage candidatePepGrid = new CandidatePeptideGridConsideringMetCleavage(aminoAcidSet, Enzyme.TRYPSIN, 4, 8, 0);
+
+        /* Generate two missed cleavages and test result is still true */
+        candidatePepGrid.addProtNTermResidue('M');
+        boolean result = candidatePepGrid.addResidue(2,'K');
+        assertEquals("grid should return true trying to add 'K' to '[M]' because [M]K has no missed cleavages",true,result);
+
+        result = candidatePepGrid.addResidue(3,'A');
+        assertEquals("grid should return false trying to add 'A' to '[M]KA' because [M]KA has one missed cleavage",false,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(0);
+        assertEquals("methionine grid should always return that it is over max number of allowed missed cleavages",true,result);
+
+        result = candidatePepGrid.gridIsOverMaxMissedCleavages(1);
+        assertEquals("grid should always return that it is over the max number of allowed missed cleavages",true,result);
+    }
+
+}

--- a/src/test/resources/mods/TestCandidatePeptideGrid.txt
+++ b/src/test/resources/mods/TestCandidatePeptideGrid.txt
@@ -1,0 +1,3 @@
+NumMods=3
+C2H3N1O1,C,fix,any,Carbamidomethyl
+HO3P,STY,opt,any,Phospho


### PR DESCRIPTION
I am proposing a solution for restricting candidate peptides to a maximum number of missed cleavages (this has a "help wanted" tag under issues). I am not sure how much detail to put in the initial pull request, but the following summarizes what was done and what steps have been taken to validate the results.

The proposed changes alter the CandidatePeptideGrid so that it will refuse to generate peptides that violate the maximum number of missed cleavages. The proposed approach should work for ntt=0/1/2. SearchParams reports an error if unspecific or no-cleavage enzymes are being used because, while the method can handle them, I couldn't think of a valid reason to use a max missed cleavages value with either of those enzymes. A default value -1=="unlimited" has been set so that not specifying a value for the parameter should generate results that match the current stable release.

I have added JUnit tests to perform automated checks for expected behavior of CandidatePepetideGrid* classes with the proposed changes that test C-term, N-term, unspecific and no-cleave enzymes and have also done the following tests with real data and Trypsin to check for inconsistencies:

   1) Compared the result peptides from the current stable release against the proposed modified version when specifying unlimited missed cleavages to verify default behavior is backward compatible.

    2) Compared the result peptides from the current stable release against the proposed modified version when specifying 1 missed cleavage to verify that peptide results unique to the current stable release have more than 1 missed cleavage.

I ma sorry for having to close and re-open this. Thanks.