### PR TITLE
Add TDF nativeID format

### DIFF
--- a/src/main/java/edu/ucsd/msjava/mzml/MzMLAdapter.java
+++ b/src/main/java/edu/ucsd/msjava/mzml/MzMLAdapter.java
@@ -67,6 +67,7 @@ public class MzMLAdapter {
                         || accNum == 1001508 || accNum == 1001526 || accNum == 1001528
                         || accNum == 1001531 || accNum == 1001532
                         || accNum == 1001559 || accNum == 1001562
+                        || accNum == 1002818
                         ) {
                     spectrumIDFormatCvParam = Constants.makeCvParam(param.getAccession(), param.getName());
                     return spectrumIDFormatCvParam;


### PR DESCRIPTION
It would be nice if it would throw this error BEFORE an hour of searching. :)
```
Search progress: 48 / 48 tasks, 100.00%         41.23 minutes elapsed
Computing q-values...
Computing q-values finished (elapsed time: 0.54 sec)
Writing results...
Unsupported mzML format: data.mzML does not contain a child term of MS:1000767 (native spectrum identifier format)
```